### PR TITLE
Update CrossEntropyError.java

### DIFF
--- a/neuroph-2.9/Contrib/src/main/java/org/neuroph/contrib/learning/CrossEntropyError.java
+++ b/neuroph-2.9/Contrib/src/main/java/org/neuroph/contrib/learning/CrossEntropyError.java
@@ -13,6 +13,10 @@ public class CrossEntropyError implements ErrorFunction, Serializable {
     private double[] errorDerivative;
     private transient double totalError;
     private transient double n;
+    
+    public CrossEntropyError(int outputSize) {
+        this.errorDerivative = new double[outputSize];
+    }
 
     @Override
     public double getTotalError() {


### PR DESCRIPTION
errorDerivative was never initialized in CrossEntropyError, causing a NullPointerException. 